### PR TITLE
Fix warning: unused variable ‘init’ [-Wunused-variable]

### DIFF
--- a/test/value_ref.cpp
+++ b/test/value_ref.cpp
@@ -176,6 +176,7 @@ public:
         {
             init_list init = 
                 { { "key", true } };
+            (void)init;
         }
     }
 


### PR DESCRIPTION
Pedantic avoidance of

```
../../libs/json/test/value_ref.cpp:177:29: error: expected primary-expression before ‘init’
  177 |             (void)init_list init =
      |                             ^~~~
```