### PR TITLE
Avoid redefinition of BOOST_JSON_SOURCE macro

### DIFF
--- a/include/boost/json/src.hpp
+++ b/include/boost/json/src.hpp
@@ -17,7 +17,9 @@ in a translation unit of the program.
 
 */
 
+#ifndef BOOST_JSON_SOURCE
 #define BOOST_JSON_SOURCE
+#endif
 
 #include <boost/json/config.hpp>
 


### PR DESCRIPTION
```
../../boost/json/src.hpp:20: warning: "BOOST_JSON_SOURCE" redefined
   20 | #define BOOST_JSON_SOURCE
      |
```

due to

https://github.com/vinniefalco/json/blob/37d0a09242bf0d116c0cd69415034ff93fd9cc02/build/Jamfile#L14

Similarly, may users do

```cpp
#define BOOST_JSON_SOURCE
#include <boost/json/src.hpp>
```
?
