### PR TITLE
Fix CMake configuration for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ else()
     target_compile_definitions(boost_json PUBLIC BOOST_JSON_STATIC_LINK=1)
 endif()
 
+include(CTest)
+
 option(BOOST_JSON_STANDALONE "Build boost::json as a static standalone library" FALSE)
 
 if(BOOST_JSON_STANDALONE)
@@ -98,7 +100,7 @@ else()
         PUBLIC
             Boost::system
     )
-    option(BUILD_TESTING "Build the tests" ON)
+
     if (BUILD_TESTING)
         add_subdirectory(bench)
         add_subdirectory(example)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -20,4 +20,4 @@ add_executable(bench
 target_include_directories(bench PRIVATE ../test)
 target_link_libraries(bench PRIVATE boost_json)
 
-add_test(json-tests json-tests)
+add_test(NAME json-bench COMMAND bench)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,4 +15,4 @@ add_executable(tests ${BOOST_JSON_TESTS_FILES})
 target_include_directories(tests PRIVATE .)
 target_link_libraries(tests PRIVATE boost_json)
 
-add_test(json-tests tests)
+add_test(NAME json-tests COMMAND tests)


### PR DESCRIPTION
A couple of things are broken that basically make `ctest` is a no-op, always:

```
Test project /home/runner/work/boost-json/boost-json/build
No tests were found!!!
```

Mind you, it is a success (`0` return code)!

This PR fixes all of them.